### PR TITLE
fix: correct regex patterns in renovate config

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -29,12 +29,12 @@
     "!ansible/services/*.yaml",
   ],
   flux: {
-    managerFilePatterns: ["/(^|/)kubernetes/.+\\.ya?ml$/"]
+    managerFilePatterns: ["(^|/)kubernetes/.+\\.ya?ml$"]
   },
   "helm-values": {
-    managerFilePatterns: ["/(^|/)kubernetes/.+\\.ya?ml$/"]
+    managerFilePatterns: ["(^|/)kubernetes/.+\\.ya?ml$"]
   },
   kubernetes: {
-    managerFilePatterns: ["/(^|/)kubernetes/.+\\.ya?ml$/"]
+    managerFilePatterns: ["(^|/)kubernetes/.+\\.ya?ml$"]
   },
 }


### PR DESCRIPTION
The managerFilePatterns had invalid regex syntax with extra '/' delimiters that prevented Renovate from finding any dependencies.

Changed from: "/(^|/)kubernetes/.+\\.ya?ml$/"
Changed to: "(^|/)kubernetes/.+\\.ya?ml$"

This fix applies to flux, helm-values, and kubernetes managers.