### PR TITLE
test: disable customManagers extend to diagnose conflict

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -6,7 +6,8 @@
     "helpers:pinGitHubActionDigests",
     "github>Subbeh/home-ops//.renovate/autoMerge.json5",
     "github>Subbeh/home-ops//.renovate/changelogs.json5",
-    "github>Subbeh/home-ops//.renovate/customManagers.json5",
+    // Temporarily disabled to test if this is causing the conflict
+    // "github>Subbeh/home-ops//.renovate/customManagers.json5",
     "github>Subbeh/home-ops//.renovate/grafanaDashboards.json5",
     "github>Subbeh/home-ops//.renovate/groups.json5",
     "github>Subbeh/home-ops//.renovate/labels.json5",


### PR DESCRIPTION
Temporarily disabling customManagers.json5 extend to test if the conflicting file patterns (both custom managers and built-in managers targeting .yaml files) are preventing built-in managers from executing.

The custom regex managers use `/\.yaml(?:\.j2)?$/` which matches the same files as the built-in flux/kubernetes/helm-values managers, potentially causing the built-in managers to skip files.