### PR TITLE
fix(renovate): use properly anchored regex patterns for fileMatch

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -26,13 +26,13 @@
   ],
   enabledManagers: ["flux", "kubernetes", "helm-values", "github-actions"],
   flux: {
-    fileMatch: ["\\.yaml$", "\\.yaml\\.j2$"],
+    fileMatch: ["(^|/)kubernetes/.+\\.ya?ml$"],
   },
   kubernetes: {
-    fileMatch: ["\\.yaml$", "\\.yaml\\.j2$"],
+    fileMatch: ["(^|/)kubernetes/.+\\.ya?ml$"],
   },
   "helm-values": {
-    fileMatch: ["\\.yaml$", "\\.yaml\\.j2$"],
+    fileMatch: ["(^|/)kubernetes/.+\\.ya?ml$"],
   },
   ignorePaths: [
     "**/*.sops.*",


### PR DESCRIPTION
The issue was that simple patterns like "\\.yaml$" don't include path anchoring. Renovate needs patterns with (^|/) to properly match file paths. Using the same pattern that worked in the minimal config: "(^|/)kubernetes/.+\\.ya?ml$"

This pattern:
- Matches from start ^ or after slash /
- Targets kubernetes/ directory
- Matches one or more characters .+
- Ends with .yaml or .yml